### PR TITLE
Always using libjpeg-turbo on OS X

### DIFF
--- a/jpeg/jpeg.go
+++ b/jpeg/jpeg.go
@@ -14,10 +14,6 @@ package jpeg
 #include <stdio.h>
 #include <jpeglib.h>
 
-// Uncomment below lines, if you want to build with homebrew ligjpeg-turbo in OS X.
-// #cgo LDFLAGS: -L/usr/local/opt/jpeg-turbo/lib
-// #cgo CFLAGS: -I/usr/local/opt/jpeg-turbo/include
-
 */
 import "C"
 

--- a/jpeg/jpeg_darwin.go
+++ b/jpeg/jpeg_darwin.go
@@ -1,0 +1,9 @@
+// +build darwin
+
+package jpeg
+
+/*
+#cgo LDFLAGS: -L/usr/local/opt/jpeg-turbo/lib
+#cgo CFLAGS: -I/usr/local/opt/jpeg-turbo/include
+*/
+import "C"


### PR DESCRIPTION
This PR activates libjpeg-turbo always on OS X.

If not installed libjpeg-turbo, to show warning messages below.

```
# github.com/pixiv/go-libjpeg/jpeg
ld: warning: directory not found for option '-L/usr/local/opt/jpeg-turbo/lib'
```