### PR TITLE
Fix #8 linker error in golang 1.5 on darwin.

### DIFF
--- a/jpeg/sourceManager.go
+++ b/jpeg/sourceManager.go
@@ -18,7 +18,9 @@ void sourceSkip(struct jpeg_decompress_struct*, long);
 boolean sourceFill(struct jpeg_decompress_struct*);
 void sourceTerm(struct jpeg_decompress_struct*);
 
-static void* get_jpeg_resync_to_restart() {
+// _get_jpeg_resync_to_restart returns the pointer of jpeg_resync_to_restart.
+// see https://github.com/golang/go/issues/9411.
+static void* _get_jpeg_resync_to_restart() {
 	return jpeg_resync_to_restart;
 }
 
@@ -109,7 +111,7 @@ func makeSourceManager(src io.Reader, dinfo *C.struct_jpeg_decompress_struct) (m
 	mgr.pub.init_source = (*[0]byte)(C.sourceInit)
 	mgr.pub.fill_input_buffer = (*[0]byte)(C.sourceFill)
 	mgr.pub.skip_input_data = (*[0]byte)(C.sourceSkip)
-	mgr.pub.resync_to_restart = (*[0]byte)(C.get_jpeg_resync_to_restart()) // default implementation
+	mgr.pub.resync_to_restart = (*[0]byte)(C._get_jpeg_resync_to_restart())
 	mgr.pub.term_source = (*[0]byte)(C.sourceTerm)
 	mgr.pub.bytes_in_buffer = 0
 	mgr.pub.next_input_byte = nil

--- a/jpeg/sourceManager.go
+++ b/jpeg/sourceManager.go
@@ -18,6 +18,10 @@ void sourceSkip(struct jpeg_decompress_struct*, long);
 boolean sourceFill(struct jpeg_decompress_struct*);
 void sourceTerm(struct jpeg_decompress_struct*);
 
+static void* get_jpeg_resync_to_restart() {
+	return jpeg_resync_to_restart;
+}
+
 */
 import "C"
 
@@ -105,7 +109,7 @@ func makeSourceManager(src io.Reader, dinfo *C.struct_jpeg_decompress_struct) (m
 	mgr.pub.init_source = (*[0]byte)(C.sourceInit)
 	mgr.pub.fill_input_buffer = (*[0]byte)(C.sourceFill)
 	mgr.pub.skip_input_data = (*[0]byte)(C.sourceSkip)
-	mgr.pub.resync_to_restart = (*[0]byte)(C.jpeg_resync_to_restart) // default implementation
+	mgr.pub.resync_to_restart = (*[0]byte)(C.get_jpeg_resync_to_restart()) // default implementation
 	mgr.pub.term_source = (*[0]byte)(C.sourceTerm)
 	mgr.pub.bytes_in_buffer = 0
 	mgr.pub.next_input_byte = nil


### PR DESCRIPTION
#8 occurs in only golang devel and similar issue reported here: https://github.com/golang/go/issues/9411.
This commit adds a workaround following above issue.

```sh
$ go version
go version devel +0b9866f Sun May 17 01:40:33 2015 +0000 darwin/amd64

$ go build -v ./jpeg/
github.com/pixiv/go-libjpeg/rgb
github.com/pixiv/go-libjpeg/jpeg

bash-3.2$ go test -v ./jpeg/
=== RUN   TestDecode
 - test: cosmos.jpg
 - test: kinkaku.jpg
--- PASS: TestDecode (1.90s)
=== RUN   TestDecodeScaled
 - test: cosmos.jpg
 - test: kinkaku.jpg
--- PASS: TestDecodeScaled (0.12s)
=== RUN   TestDecodeIntoRGBA
--- SKIP: TestDecodeIntoRGBA (0.00s)
	jpeg_test.go:109: This build is not support DecodeIntoRGBA.
=== RUN   TestDecodeScaledIntoRGBA
--- SKIP: TestDecodeScaledIntoRGBA (0.00s)
	jpeg_test.go:128: This build is not support DecodeIntoRGBA.
=== RUN   TestDecodeScaledIntoRGB
 - test: cosmos.jpg
 - test: kinkaku.jpg
--- PASS: TestDecodeScaledIntoRGB (0.13s)
=== RUN   TestDecodeSubsampledImage
 - test: checkerboard_444.jpg
 - test: checkerboard_440.jpg
 - test: checkerboard_422.jpg
 - test: checkerboard_420.jpg
--- PASS: TestDecodeSubsampledImage (0.07s)
=== RUN   TestDecodeAndEncode
 - test: cosmos.jpg
 - test: kinkaku.jpg
--- PASS: TestDecodeAndEncode (0.02s)
=== RUN   TestDecodeAndEncodeSubsampledImages
 - test: checkerboard_444.jpg
 - test: checkerboard_440.jpg
 - test: checkerboard_422.jpg
 - test: checkerboard_420.jpg
--- PASS: TestDecodeAndEncodeSubsampledImages (0.01s)
=== RUN   TestDecodeConfig
 - test: cosmos.jpg
 - test: kinkaku.jpg
--- PASS: TestDecodeConfig (0.00s)
=== RUN   TestNewYCbCrAlignedWithLandscape
--- PASS: TestNewYCbCrAlignedWithLandscape (0.00s)
=== RUN   TestNewYCbCrAlignedWithPortrait
--- PASS: TestNewYCbCrAlignedWithPortrait (0.00s)
PASS
ok  	github.com/pixiv/go-libjpeg/jpeg	2.289s
```