### PR TITLE
Use JCS_ALPHA_EXTENSIONS to detect JCS_EXT_RGBA support

### DIFF
--- a/jpeg/decompress.go
+++ b/jpeg/decompress.go
@@ -39,7 +39,7 @@ static int DCT_v_scaled_size(j_decompress_ptr dinfo, int component) {
 }
 
 static J_COLOR_SPACE getJCS_EXT_RGBA(void) {
-#ifdef JCS_EXT_RGBA
+#ifdef JCS_ALPHA_EXTENSIONS
 	return JCS_EXT_RGBA;
 #endif
   return JCS_UNKNOWN;


### PR DESCRIPTION
I was having trouble trying to use `DecodeIntoRGBA` on OS X with libjpeg-turbo installed and it was also failing on a Docker alpine install as well. Looking into things further it appears to be also skipping support for that in the unit tests rather than just for libjpeg and you will see the same thing with the output shown in https://github.com/pixiv/go-libjpeg/issues/18

The travis builds also show this being incorrectly skipped, e.g. https://travis-ci.org/pixiv/go-libjpeg/jobs/129381454 has `jpeg_test.go:131: This build is not support DecodeIntoRGBA.` even for the libjpeg-turbo run.

I believe the problem is in the `getJCS_EXT_RGBA` function trying to check if an enum has been defined, returning it if it is, but it always returns 0 so any tests based on it fail. I changed it to use the `JCS_ALPHA_EXTENSIONS` definition which I believe is for this purpose and it works as expected.