### PR TITLE
Support encoding rgb.Image.

### DIFF
--- a/jpeg/issue51_test.go
+++ b/jpeg/issue51_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/pixiv/go-libjpeg/jpeg"
 )
 
-var data = []byte("\xff\xd8\xff\xdb\x00C\x000000000000000" +
+var data51 = []byte("\xff\xd8\xff\xdb\x00C\x000000000000000" +
 	"00000000000000000000" +
 	"00000000000000000000" +
 	"00000000000\xff\xc9\x00\v\b00\x000" +
@@ -15,5 +15,5 @@ var data = []byte("\xff\xd8\xff\xdb\x00C\x000000000000000" +
 
 // https://github.com/pixiv/go-libjpeg/issues/51
 func TestIssue51(t *testing.T) {
-	jpeg.Decode(bytes.NewReader(data), &jpeg.DecoderOptions{})
+	jpeg.Decode(bytes.NewReader(data51), &jpeg.DecoderOptions{})
 }

--- a/jpeg/issue51_test.go
+++ b/jpeg/issue51_test.go
@@ -7,13 +7,13 @@ import (
 	"github.com/pixiv/go-libjpeg/jpeg"
 )
 
-var data51 = []byte("\xff\xd8\xff\xdb\x00C\x000000000000000" +
-	"00000000000000000000" +
-	"00000000000000000000" +
-	"00000000000\xff\xc9\x00\v\b00\x000" +
-	"\x01\x01\x14\x00\xff\xda\x00\b\x01\x010\x00?\x0000")
-
 // https://github.com/pixiv/go-libjpeg/issues/51
 func TestIssue51(t *testing.T) {
-	jpeg.Decode(bytes.NewReader(data51), &jpeg.DecoderOptions{})
+	data := []byte("\xff\xd8\xff\xdb\x00C\x000000000000000" +
+		"00000000000000000000" +
+		"00000000000000000000" +
+		"00000000000\xff\xc9\x00\v\b00\x000" +
+		"\x01\x01\x14\x00\xff\xda\x00\b\x01\x010\x00?\x0000")
+
+	jpeg.Decode(bytes.NewReader(data), &jpeg.DecoderOptions{})
 }

--- a/jpeg/issue55_test.go
+++ b/jpeg/issue55_test.go
@@ -1,0 +1,29 @@
+package jpeg_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/pixiv/go-libjpeg/jpeg"
+)
+
+var data55 = []byte("\xff\xd8\xff\xdb\x00C\x000000000000000" +
+	"00000000000000000000" +
+	"00000000000000000000" +
+	"00000000000\xff\xc0\x00\x11\b\x00000" +
+	"\x03R\"\x00G\x11\x00B\x11\x00\xff\xda\x00\f\x03R\x00G\x00B" +
+	"\x00")
+
+// https://github.com/pixiv/go-libjpeg/issues/55
+func TestIssue55(t *testing.T) {
+	img, err := jpeg.Decode(bytes.NewReader(data55), &jpeg.DecoderOptions{})
+	if err != nil {
+		return
+	}
+
+	var w bytes.Buffer
+	err = jpeg.Encode(&w, img, &jpeg.EncoderOptions{})
+	if err != nil {
+		t.Errorf("encoding after decoding failed: %v", err)
+	}
+}

--- a/jpeg/issue55_test.go
+++ b/jpeg/issue55_test.go
@@ -7,17 +7,18 @@ import (
 	"github.com/pixiv/go-libjpeg/jpeg"
 )
 
-var data55 = []byte("\xff\xd8\xff\xdb\x00C\x000000000000000" +
-	"00000000000000000000" +
-	"00000000000000000000" +
-	"00000000000\xff\xc0\x00\x11\b\x00000" +
-	"\x03R\"\x00G\x11\x00B\x11\x00\xff\xda\x00\f\x03R\x00G\x00B" +
-	"\x00")
-
 // https://github.com/pixiv/go-libjpeg/issues/55
-func TestIssue55(t *testing.T) {
-	img, err := jpeg.Decode(bytes.NewReader(data55), &jpeg.DecoderOptions{})
+func TestDecodeAndEncodeRGBJPEG(t *testing.T) {
+	data := []byte("\xff\xd8\xff\xdb\x00C\x000000000000000" +
+		"00000000000000000000" +
+		"00000000000000000000" +
+		"00000000000\xff\xc0\x00\x11\b\x00000" +
+		"\x03R\"\x00G\x11\x00B\x11\x00\xff\xda\x00\f\x03R\x00G\x00B" +
+		"\x00")
+
+	img, err := jpeg.Decode(bytes.NewReader(data), &jpeg.DecoderOptions{})
 	if err != nil {
+		t.Log(err)
 		return
 	}
 


### PR DESCRIPTION
In #55, RGB JPEG is decoded into `*rgb.Image`.
This PR makes to support encoding `*rgb.Image` .